### PR TITLE
Added support for nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,30 @@ module.exports = function createMarkup(obj) {
   for (i = 0; i < len; i++) {
     var key = keys[i]
     var val = obj[key]
-    result += hyphenate(key) + ':' + addPx(key, val) + ';'
+    var hyphenated = hyphenate(key)
+
+    /* Recursively process nested selectors */
+    if (isPlainObj(val)) {
+      result += hyphenated + ':{' + createMarkup(val) + '}'
+    } else {
+      result += hyphenated + ':' + addPx(key, val) + ';'
+    }
   }
 
   return result
+}
+
+function isPlainObj(obj) {
+  try {
+    if (typeof obj === 'object' && obj !== null) {
+      /* Prefer Object.getPrototypeOf if avail, or fallback for pre-es5 */
+      if (typeof Object.getPrototypeOf === 'function') {
+        var proto = Object.getPrototypeOf(obj)
+        return proto === Object.prototype || proto === null
+      }
+      return Object.prototype.toString.call(obj) === '[object Object]'
+    }
+  } catch (e) {}
+
+  return false
 }


### PR DESCRIPTION
Currently, if a css object has nested classes  the resulting css will be `[object Object]`

This PR will process them correctly by recursively calling for any nested objects, building the nested selectors correctly.

Added isPlainObj util function, can modify to something simpler if needed.